### PR TITLE
Ensure the tile width and height values are integers.

### DIFF
--- a/src/jquery.qrcode.js
+++ b/src/jquery.qrcode.js
@@ -28,8 +28,8 @@
 			var ctx		= canvas.getContext('2d');
 
 			// compute tileW/tileH based on options.width/options.height
-			var tileW	= options.width  / qrcode.getModuleCount();
-			var tileH	= options.height / qrcode.getModuleCount();
+			var tileW	= Math.floor(options.width  / qrcode.getModuleCount());
+			var tileH	= Math.floor(options.height / qrcode.getModuleCount());
 
 			// draw in the canvas
 			for( var row = 0; row < qrcode.getModuleCount(); row++ ){


### PR DESCRIPTION
This should address the issue here:

https://github.com/jeromeetienne/jquery-qrcode/issues/7

Currently, if the specified width / number of calculated modules is a non-integer value, fillRect() will attempt a sub-pixel draw resulting in artifacts between the rendered tiles.

By flooring the tile width and height, this problem should be alleviated.
