### PR TITLE
fixed typo and link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then you add the *qrcode* in this container by
 
     jQuery('#qrcode').qrcode("this plugin is great");
 
-This is it. see it <a href='examples/basic.html'>live</a>.
+This is it. see it <a href='http://jeromeetienne.github.com/jquery-qrcode/examples/basic.html'>live</a>.
 
 You can set the height and width of the generated qrcode:
 


### PR DESCRIPTION
changed 2 instances of 'jquery' to 'jQuery' and made the live link point to the live example instead of the example code.
