### PR TITLE
.noConflict() compliance: only reference $, not jQuery, inside the closure

### DIFF
--- a/src/jquery.qrcode.js
+++ b/src/jquery.qrcode.js
@@ -83,7 +83,7 @@
 
 		return this.each(function(){
 			var element	= options.render == "canvas" ? createCanvas() : createTable();
-			jQuery(element).appendTo(this);
+			$(element).appendTo(this);
 		});
 	};
 })( jQuery );


### PR DESCRIPTION
According to the jQuery coding standards (http://wiki.jqueryui.com/w/page/12137737/Coding-standards), you shouldn't reference 'jQuery' inside the closure, only '$':

> .noConflict() compliance
> 
> Wrap plugins in a closure that passes jQuery in as a parameter. Inside the closure, only reference jQuery through the parameter variable.
> 
> (function( $ ) {
>     // inside here only reference $, not jQuery
> }( jQuery ) );
