### PR TITLE
ensure the width and height of the table are equal when render with 'table'

### DIFF
--- a/src/jquery.qrcode.js
+++ b/src/jquery.qrcode.js
@@ -59,11 +59,12 @@
 				.css("height", options.height+"px")
 				.css("border", "0px")
 				.css("border-collapse", "collapse")
-				.css('background-color', options.background);
+				.css('background-color', options.background)
+				.css('table-layout', "fixed");
 		  
 			// compute tileS percentage
-			var tileW	= options.width / qrcode.getModuleCount();
-			var tileH	= options.height / qrcode.getModuleCount();
+			var tileW	= Math.round(options.width / qrcode.getModuleCount());
+			var tileH	= Math.round(options.height / qrcode.getModuleCount());
 
 			// draw in the table
 			for(var row = 0; row < qrcode.getModuleCount(); row++ ){
@@ -72,6 +73,7 @@
 				for(var col = 0; col < qrcode.getModuleCount(); col++ ){
 					$('<td></td>')
 						.css('width', tileW+"px")
+						.css('padding', 0)
 						.css('background-color', qrcode.isDark(row, col) ? options.foreground : options.background)
 						.appendTo($row);
 				}	


### PR DESCRIPTION
if the width and height are not equal,it will be wrong in sometimes

example code:

qrcode({text:'otpauth://totp/zewenzhang@tom.com?secret=RRJC2J4TV3366ULY', width:150, height:150, render:'table'});
