### PR TITLE
set DOCTYPE or IE9 won't render the canvas examples

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 <title>basic example</title>

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 <title>Demo page</title>


### PR DESCRIPTION
IE9 will exit with "TypeError: object doesn't support property or method 'getContext'" if you don't set the DOCTYPE.

This should be merged into `gh-pages` too, or, even more: you should have only one branch :)
