### PR TITLE
Border option added to canvas

### DIFF
--- a/src/jquery.qrcode.js
+++ b/src/jquery.qrcode.js
@@ -11,6 +11,7 @@
 			render		: "canvas",
 			width		: 256,
 			height		: 256,
+			border		: 0,
 			typeNumber	: -1,
 			correctLevel	: QRErrorCorrectLevel.H,
                         background      : "#ffffff",
@@ -25,8 +26,14 @@
 
 			// create canvas element
 			var canvas	= document.createElement('canvas');
-			canvas.width	= options.width;
-			canvas.height	= options.height;
+			if (options.border !== 0) {
+				var border		= options.border * 2;
+				canvas.width	= options.width + border;
+				canvas.height	= options.height + border;
+			} else {
+				canvas.width	= options.width;
+				canvas.height	= options.height;
+			}
 			var ctx		= canvas.getContext('2d');
 
 			// compute tileW/tileH based on options.width/options.height
@@ -39,9 +46,21 @@
 					ctx.fillStyle = qrcode.isDark(row, col) ? options.foreground : options.background;
 					var w = (Math.ceil((col+1)*tileW) - Math.floor(col*tileW));
 					var h = (Math.ceil((row+1)*tileW) - Math.floor(row*tileW));
-					ctx.fillRect(Math.round(col*tileW),Math.round(row*tileH), w, h);  
+					if (options.border !== 0) {
+						ctx.fillRect(Math.round(col*tileW +(border/2)),Math.round(row*tileH +(border/2)), w, h);
+					} else {
+						ctx.fillRect(Math.round(col*tileW),Math.round(row*tileH), w, h);
+					}
 				}	
 			}
+
+			// Draw border
+			if (options.border !== 0) {
+				ctx.lineWidth   = border;
+				ctx.strokeStyle = options.background;
+				ctx.strokeRect(0, 0, options.width + border, options.height + border);
+			}
+
 			// return just built canvas
 			return canvas;
 		}


### PR DESCRIPTION
I added a border to the `canvas` element, because this way I can right click -> save the png image with border without a trip to Photoshop. Adding border in CSS is not sufficient, because it's not saved with the image. border is not added to the `table`, because you can do that easily with CSS.

Default value is 0 and the modified lines are turned off this way, so it will not brake anything, but this needs testing.

I didn't created a minified build, because I'm on windows.